### PR TITLE
image and horse generation refactoring

### DIFF
--- a/classDefinitions.js
+++ b/classDefinitions.js
@@ -68,6 +68,7 @@ class horse {
   this.horseTrust = 0;
   this.horseName = "unnamed";
   this.horseIcon = "";
+  this.horseSpriteSheet = "";
   this.horseDisplayed = "N";
   this.horseBeingRidden = "N";
   this.saddlePad = "";

--- a/helpers.js
+++ b/helpers.js
@@ -126,61 +126,91 @@ function randomWorldWilds(horse, minRow, maxRow, minCol, maxCol) {
 
   function drawHorse(testHorse) {
 
-    ctx.drawImage(testHorse.baseColor,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
-      playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
-    ctx.drawImage(testHorse.gradient,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
-      playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
-    ctx.drawImage(testHorse.markings,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
-      playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
-    ctx.drawImage(testHorse.horseBase,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
-      playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
-    ctx.drawImage(testHorse.maneBase,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
-      playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
-    ctx.drawImage(testHorse.maneColor,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
-      playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
-    ctx.drawImage(testHorse.maneShade,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
-      playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
-      
-      if(testHorse.saddlePad != "") {
-        var saddlePDImg = new Image();
-        saddlePDImg.src = testHorse.saddlePad.icon;
-        ctx.drawImage(saddlePDImg,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
-          playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
-      }
-      if(testHorse.bridle != "") {
-        var bridleImg = new Image();
-        bridleImg.src = testHorse.bridle.icon;
-        ctx.drawImage(bridleImg,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
-          playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
-      }
-      if(testHorse.saddle != "") {
-        var saddleImg = new Image();
-        saddleImg.src = testHorse.saddle.icon
-        ctx.drawImage(saddleImg,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
-          playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
-      }
-
-
-      if (testHorse.horseIcon == "") {
-      var x = testHorse.HorsePosCol*32; 
-      var y = testHorse.HorsePosRow*32;  
-      var width = 32;
-      var height = 32;
-
-      var imageData = ctx.getImageData(x, y, width, height);
+    if(testHorse.horseSpriteSheet == "") {
+      var x = 0; 
+      var y = 0;  
+      var width = 64;
+      var height = 128;
 
       var tempCanvas = document.createElement('canvas');
       tempCanvas.width = width;
       tempCanvas.height = height;
       var tempCtx = tempCanvas.getContext('2d');
 
+      tempCtx.drawImage(testHorse.baseColor, 0, 0);
+      tempCtx.drawImage(testHorse.gradient, 0, 0);
+      tempCtx.drawImage(testHorse.markings, 0, 0);
+      tempCtx.drawImage(testHorse.horseBase, 0, 0);
+      tempCtx.drawImage(testHorse.maneBase, 0, 0);
+      tempCtx.drawImage(testHorse.maneColor, 0, 0);
+      tempCtx.drawImage(testHorse.maneShade, 0, 0);
+
+      var imageData = tempCtx.getImageData(x, y, width, height);
+      console.log(imageData);
+
       tempCtx.putImageData(imageData, 0, 0);
 
       var savedImageDataURL = tempCanvas.toDataURL();
 
-      testHorse.horseIcon = savedImageDataURL;
+      testHorse.horseSpriteSheet = savedImageDataURL;  
+
+      if (testHorse.horseIcon == "") {
+        var x = 0;
+        var y = 0;
+        var width = 32;
+        var height = 32;
+  
+        var imageData = tempCtx.getImageData(x, y, width, height);
+  
+        var tempCanvas = document.createElement('canvas');
+        var tempCtx = tempCanvas.getContext('2d');
+        tempCanvas.width = width;
+        tempCanvas.height = height;
+        tempCtx.putImageData(imageData, 0, 0);
+
+        testHorse.horseIcon = tempCanvas.toDataURL();
+      }
+
+      tempCtx.clearRect(0, 0, tempCanvas.width, tempCanvas.height);
+    } 
+    
+    if (!(testHorse.horseSpriteSheet instanceof Image)) {
+        var tempHold = testHorse.horseSpriteSheet;
+        testHorse.horseSpriteSheet = new Image();
+        testHorse.horseSpriteSheet.src = tempHold;
     }
 
+    ctx.drawImage(testHorse.horseSpriteSheet,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
+      playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
+
+
+    if(testHorse.saddlePad != "") {
+      if (!(testHorse.saddlePad.icon instanceof Image)) {
+        var tempHold = testHorse.saddlePad.icon;
+        testHorse.saddlePad.icon = new Image();
+        testHorse.saddlePad.icon.src = tempHold;
+      }
+      ctx.drawImage(testHorse.saddlePad.icon,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
+        playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
+      }
+    if(testHorse.bridle != "") {
+      if (!(testHorse.bridle.icon instanceof Image)) {
+        var tempHold = testHorse.bridle.icon;
+        testHorse.bridle.icon = new Image();
+        testHorse.bridle.icon.src = tempHold;
+      }
+      ctx.drawImage(testHorse.bridle.icon,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
+        playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
+  }
+    if(testHorse.saddle != "") {
+      if(!(testHorse.saddle.icon instanceof Image)) {
+        var tempHold = testHorse.saddle.icon;
+        testHorse.saddle.icon = new Image();
+        testHorse.saddle.icon.src = tempHold;
+      }
+      ctx.drawImage(testHorse.saddle.icon,testHorse.HorseCol * playerCharacter.SpriteWidth, testHorse.HorseRow * playerCharacter.SpriteHeight, 
+        playerCharacter.SpriteWidth, playerCharacter.SpriteHeight, testHorse.HorsePosCol*32, testHorse.HorsePosRow*32, playerCharacter.SpriteWidth, playerCharacter.SpriteHeight);
+    }
   }
 
   function validateHorseName(horse) {

--- a/items.js
+++ b/items.js
@@ -4,7 +4,7 @@ var possibleItems = {
     Background: {
       1: {
         name: "seedling",
-        icon: "seedlings.png",
+        icon: "assetsImg/seedlings.png",
         type: "Enviromental",
         ownedByPlayer: 0,
       },
@@ -14,19 +14,19 @@ var possibleItems = {
     Savannah: {
       1: {
         name: "prairie flower",
-        icon: "yellowFlower.png",
+        icon: "assetsImg/yellowFlower.png",
         type: "Enviromental",
         ownedByPlayer: 0,
       },
       2: {
         name: "stardust flower",
-        icon: "purpFlower.png",
+        icon: "assetsImg/purpFlower.png",
         type: "Enviromental",
         ownedByPlayer: 0,
       },
       3: {
         name: "lilly",
-        icon: "lillyItem.png",
+        icon: "assetsImg/lillyItem.png",
         type: "Enviromental",
         ownedByPlayer: 0,
       }
@@ -50,19 +50,19 @@ var possibleItems = {
     Path: {
       1: {
         name: "luvletter",
-        icon: "luvletter.png",
+        icon: "assetsImg/luvletter.png",
         type: "Enviromental",
         ownedByPlayer: 0,
       },
       2: {
         name: "witch's hat",
-        icon: "witchhat.png",
+        icon: "assetsImg/witchhat.png",
         type: "Enviromental",
         ownedByPlayer: 0,
       },
       3: {
         name: "mysterious brew",
-        icon: "brew.png",
+        icon: "assetsImg/brew.png",
         type: "Enviromental",
         ownedByPlayer: 0,
       },
@@ -70,7 +70,7 @@ var possibleItems = {
     StoneSwamp: {
       1: {
         name: "geode",
-        icon: "geode.png",
+        icon: "assetsImg/geode.png",
         type: "Enviromental",
         ownedByPlayer: 0,
       },

--- a/npcDefinitions.js
+++ b/npcDefinitions.js
@@ -46,7 +46,7 @@ function createQuests() {
  eightballQuest1 = new classDefinitions.horseQuest("Heard you're in the horse pawning biz? Need a turbulent one, something I can slap around.", 
   "Gonna put some miles on this thang..",0,50,0,10,20,40,40,50,0,800); 
   eightballQuest2 = new classDefinitions.itemQuest("Been lookin for a special lady. Problem is, she's a bit hard to reach. I'll do ya good if you gimme a hand.","Gone. Without a trace.. But I'll see you soon, let our hearts commence- Oh, here take this and bounce. I've got my work cut out for me", new Map([["witch's hat",1]]),100); 
-  damonShop1 = new classDefinitions.shopQuest(["Buy before you try. No refunds"], ["Luck"], new Map([[items.horseTack.saddlePads[helpers.randomIntFromInterval(1,20)],100], [items.horseTack.saddles[helpers.randomIntFromInterval(1,3)],200], [items.horseTack.bridles[helpers.randomIntFromInterval(1,3)],150]]));
+  damonShop1 = new classDefinitions.shopQuest(["Buy before you try. No refunds"], ["Luck"], new Map([[items.horseTack.saddlePads[helpers.randomIntFromInterval(1,20)],0], [items.horseTack.saddles[helpers.randomIntFromInterval(1,3)],0], [items.horseTack.bridles[helpers.randomIntFromInterval(1,3)],0]]));
   sravanthiQuest1 = new classDefinitions.horseQuest("I have space in the stable to rehome a mustang. Just as long as they're at least 10 acclimated to people, I'll take 'em","This pony's gonna make someone very happy!" 
     ,0,50,0,50,0,50,0,50,10,200); 
   scratQuest1 = new classDefinitions.itemQuest("Jigs has the memory of a goldfish. Mind picking up those drawings he leaves out. EVERYWHERE", "Thanks. This will put off another visit from those damn enviromentalists", new Map([["luvletter",10]]), 170);

--- a/saveAndLoad.js
+++ b/saveAndLoad.js
@@ -37,6 +37,10 @@ function saveGame() {
                 HorseMapPosCol: horse.HorseMapPosCol,
                 HorsePosRow: horse.HorsePosRow,
                 HorsePosCol: horse.HorsePosCol,
+                saddlePad: convertTackToSrc(horse.saddlePad),
+                saddle: convertTackToSrc(horse.saddle),
+                bridle: convertTackToSrc(horse.bridle),
+                horseSpriteSheet: horse.horseSpriteSheet.src
             };
         });
         localStorage.setItem("playerHorses", JSON.stringify(horseToSave));
@@ -47,6 +51,15 @@ function saveGame() {
         localStorage.setItem("spriteMapRow", JSON.stringify(playerCharacter.spriteMapRow));
         localStorage.setItem("SpriteColPos", JSON.stringify(playerCharacter.SpriteColPos));
         localStorage.setItem("SpriteColRow", JSON.stringify(playerCharacter.SpriteRowPos));
+}
+
+function convertTackToSrc(item) {
+   if(item.icon instanceof Image) {
+    item.icon = item.icon.src;
+    return item;
+   } else {
+    return item;
+   }
 }
 
 function loadGame() {


### PR DESCRIPTION
Fix image file paths for items
Make tack not have to convert to objects each time they're drawn, just once on first draw.
Horse generated are now saved with their colored sprite sheet and only drawn once per draw.